### PR TITLE
Feature/update-plan-and-product

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ build/Release
 
 # Dependency directories
 node_modules/
+node_modules
 jspm_packages/
 
 # TypeScript v1 declaration files

--- a/src/VindiWoocommerce.php
+++ b/src/VindiWoocommerce.php
@@ -56,8 +56,9 @@ class WC_Vindi_Payment extends AbstractInstance
     require_once $this->getPath() . '/i18n/Languages.php';
     require_once $this->getPath() . '/services/VindiHelpers.php';
 
-    // Loading Abstract Method
+    // Loading Abstract Method and Utils
     require_once $this->getPath() . '/utils/PaymentGateway.php';
+    require_once $this->getPath() . '/utils/Conversions.php';
 
     require_once $this->getPath() . '/includes/admin/CouponsMetaBox.php';
     require_once $this->getPath() . '/includes/admin/Settings.php';

--- a/src/VindiWoocommerce.php
+++ b/src/VindiWoocommerce.php
@@ -26,7 +26,6 @@ class WC_Vindi_Payment extends AbstractInstance
 
 
       $this->languages   = new VindiLanguages();
-      // $this->gateways = new VindiGateways();
 
       $this->settings    = new VindiSettings();
       $this->controllers = new VindiControllers($this->settings);

--- a/src/controllers/CustomerController.php
+++ b/src/controllers/CustomerController.php
@@ -98,7 +98,7 @@ class CustomerController
 
     $user = $customer->get_data();
     $phones = array();
-    foreach($vindiUser['phones'] as $phone):
+    foreach ($vindiUser['phones'] as $phone) :
       $phones[$phone['phone_type']] = $phone['id'];
     endforeach;
 
@@ -164,7 +164,7 @@ class CustomerController
 
     // Delete customer profile
     $deletedUser = $this->routes->deleteCustomer(
-      $vindi_customer_id,
+      $vindi_customer_id
     )['customer'];
   }
 }

--- a/src/controllers/PlansController.php
+++ b/src/controllers/PlansController.php
@@ -37,23 +37,20 @@ class PlansController
   /**
    * When the user creates a product in Woocomerce, it is created in the Vindi.
    *
-   * @since 1.2.1
+   * @since 1.2.2
    * @version 1.2.0
    */
-  function create($post_id, $post, $update)
+  function create($post_id, $post, $update, $recreated = false)
   {
     // Check if the post is product
     if (get_post_type($post_id) != 'product') {
       return;
     }
-
-    $product = wc_get_product($post_id);
-
-
     // Check if it's a new post
     // The $update value is unreliable because of the auto_draft functionality
-    if(get_post_status($post_id) != 'publish' || !empty(get_post_meta($post_id, 'vindi_product_created', true))) {
-      return;
+    if(!$recreated && get_post_status($post_id) != 'publish' || !empty(get_post_meta($post_id, 'vindi_product_created', true))) {
+
+      return $this->update($post_id);
     }
 
     $product = wc_get_product($post_id);
@@ -112,10 +109,9 @@ class PlansController
         ))['plan'];
 
         // Saving product id and plan in the WC goal
-        VindiHelpers::wc_post_meta($data['id'], array(
-          'vindi_product_id' => $createProduct['id'],
-          'vindi_plan_id' => $createPlan['id'],
-        ));
+        update_post_meta( $post_id, 'vindi_product_id', $createProduct['id'] );
+
+        update_post_meta( $post_id, 'vindi_plan_id', $createPlan['id'] );
 
         update_post_meta( $post_id, 'vindi_product_created', true );
 
@@ -125,6 +121,12 @@ class PlansController
     }
 
     $data = $product->get_data();
+
+
+    $trigger_day = VindiConversions::convertTriggerToDay(
+      $product->get_meta('_subscription_trial_length'),
+      $product->get_meta('_subscription_trial_period')
+    );
 
     // Creates the product within the Vindi
     $createProduct = $this->routes->createProduct(array(
@@ -145,7 +147,7 @@ class PlansController
       'interval' => $product->get_meta('_subscription_period') . 's',
       'interval_count' => intval($product->get_meta('_subscription_period_interval')),
       'billing_trigger_type' => 'beginning_of_period',
-      'billing_trigger_day' => $product->get_meta('_subscription_trial_length'),
+      'billing_trigger_day' => $trigger_day,
       'billing_cycles' => ($product->get_meta('_subscription_length') == 0) ? null : $product->get_meta('_subscription_length'),
       'code' => 'WC-' . $data['id'],
       'description' => $data['description'],
@@ -160,18 +162,143 @@ class PlansController
     ))['plan'];
 
     // Saving product id and plan in the WC goal
-    VindiHelpers::wc_post_meta($data['id'], array(
-      'vindi_product_id' => $createProduct['id'],
-      'vindi_plan_id' => $createPlan['id'],
-    ));
+    update_post_meta( $post_id, 'vindi_product_id', $createProduct['id'] );
+
+    update_post_meta( $post_id, 'vindi_plan_id', $createPlan['id'] );
 
     update_post_meta( $post_id, 'vindi_product_created', true );
   }
 
-  function update($post_id, $post)
+  function update($post_id)
   {
 
-    $subscription = $this->get_product(33);
+    $product = wc_get_product($post_id);
+
+    // Check if the post is of the signature type
+    if (!in_array($product->get_type(), $this->types)) {
+      return;
+    }
+
+    // Checks whether there is a vindi plan ID created within
+    if($product->get_type() == 'subscription') {
+
+      $vindi_plan_id = get_post_meta($post_id, 'vindi_plan_id');
+
+      if(empty($vindi_plan_id)) {
+
+        return $this->create($post_id, '', '', true);
+      }
+
+    }
+
+    // Checks if the plan is a variation and creates it
+    if($product->get_type() == 'variable-subscription') {
+
+      $variations = $product->get_available_variations();
+
+      foreach ($variations as $variation) {
+        $data = wc_get_product($variation['variation_id']);
+
+        // Checks whether there is a vindi plan ID created within
+        $vindi_plan_id = get_post_meta($variation['variation_id'], 'vindi_plan_id');
+        $vindi_product_id = get_post_meta($variation['variation_id'], 'vindi_product_id');
+
+        if(empty($vindi_plan_id)) {
+
+          return $this->create($post_id, '', '', true);
+          break;
+        }
+
+        $data = $data->get_data();
+
+        $trigger_day = VindiConversions::convertTriggerToDay(
+                        $product->get_meta('_subscription_trial_length'),
+                        $product->get_meta('_subscription_trial_period')
+                      );
+
+        // Updates the product within the Vindi
+        $updateProduct = $this->routes->updateProduct(
+          $vindi_product_id[0],
+            array(
+            'name' => PREFIX_PRODUCT . $data['name'],
+            'code' => 'WC-' . $data['id'],
+            'status' => ($data['status'] == 'publish') ? 'active' : 'inactive',
+            'description' => $data['description'],
+            'invoice' => 'always',
+            'pricing_schema' => array(
+              'price' => ($data['price']) ? $data['price'] : 0,
+              'schema_type' => 'flat',
+            )
+          )
+        )['product'];
+
+        // Updates the plan within the Vindi
+        $updatePlan = $this->routes->updatePlan(
+          $vindi_plan_id[0],
+            array(
+            'name' => PREFIX_PLAN . $data['name'],
+            'interval' => $product->get_meta('_subscription_period') . 's',
+            'interval_count' => intval($product->get_meta('_subscription_period_interval')),
+            'billing_trigger_type' => 'beginning_of_period',
+            'billing_trigger_day' => $trigger_day,
+            'billing_cycles' => ($product->get_meta('_subscription_length') == 0) ? null : $product->get_meta('_subscription_length'),
+            'code' => 'WC-' . $data['id'],
+            'description' => $data['description'],
+            'installments' => 1,
+            'status' => ($data['status'] == 'publish') ? 'active' : 'inactive',
+          )
+        )['plan'];
+
+      }
+
+      return;
+    }
+
+    $data = $product->get_data();
+
+    $trigger_day = VindiConversions::convertTriggerToDay(
+      $product->get_meta('_subscription_trial_length'),
+      $product->get_meta('_subscription_trial_period')
+    );
+
+    $vindi_product_id = get_post_meta($post_id, 'vindi_product_id');
+
+    // Updates the product within the Vindi
+    $updateProduct = $this->routes->updateProduct(
+      $vindi_product_id[0],
+      array(
+        'name' => PREFIX_PRODUCT . $data['name'],
+        'code' => 'WC-' . $data['id'],
+        'status' => ($data['status'] == 'publish') ? 'active' : 'inactive',
+        'description' => $data['description'],
+        'invoice' => 'always',
+        'pricing_schema' => array(
+          'price' => ($data['price']) ? $data['price'] : 0,
+          'schema_type' => 'flat',
+        )
+      )
+    )['product'];
+
+
+    $vindi_plan_id = get_post_meta($post_id, 'vindi_plan_id');
+
+    // Updates the plan within the Vindi
+    $updatePlan = $this->routes->updatePlan(
+      $vindi_plan_id[0],
+      array(
+        'name' => PREFIX_PLAN . $data['name'],
+        'interval' => $product->get_meta('_subscription_period') . 's',
+        'interval_count' => intval($product->get_meta('_subscription_period_interval')),
+        'billing_trigger_type' => 'beginning_of_period',
+        'billing_trigger_day' => $trigger_day,
+        'billing_cycles' => ($product->get_meta('_subscription_length') == 0) ? null : $product->get_meta('_subscription_length'),
+        'code' => 'WC-' . $data['id'],
+        'description' => $data['description'],
+        'installments' => 1,
+        'status' => ($data['status'] == 'publish') ? 'active' : 'inactive',
+        )
+    )['plan'];
+
   }
 
   /**

--- a/src/controllers/PlansController.php
+++ b/src/controllers/PlansController.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * Creation and edition of products with reflection within Vindi
+ *
+ * Warning, by default, this class does not return any status.
+ *
+ * @since 1.0.0
+ *
+ */
 
 class PlansController
 {
@@ -29,8 +37,8 @@ class PlansController
   /**
    * When the user creates a product in Woocomerce, it is created in the Vindi.
    *
-   * @since 1.0.0
-   * @version 1.0.0
+   * @since 1.2.1
+   * @version 1.2.0
    */
   function create($post_id, $post, $update)
   {
@@ -50,6 +58,69 @@ class PlansController
     // Check if the post is of the signature type
     if (!in_array($product->get_type(), $this->types)) {
       return;
+    }
+
+    // Check if the post is Variable
+    if($product->get_type() == 'variable-subscription') {
+
+      $variations = $product->get_available_variations();
+
+      foreach ($variations as $variation) {
+        $data = wc_get_product($variation['variation_id']);
+
+        $data = $data->get_data();
+
+        // print_r($product->get_meta('_subscription_trial_length'));
+
+        $conversion = VindiConversions::convertTriggerToDay($product->get_meta('_subscription_trial_length'));
+
+        print_r($conversion);
+        die();
+
+        // Creates the product within the Vindi
+        $createProduct = $this->routes->createProduct(array(
+          'name' => PREFIX_PRODUCT . $data['name'],
+          'code' => 'WC-' . $data['id'],
+          'status' => ($data['status'] == 'publish') ? 'active' : 'inactive',
+          'description' => $data['description'],
+          'invoice' => 'always',
+          'pricing_schema' => array(
+            'price' => ($data['price']) ? $data['price'] : 0,
+            'schema_type' => 'flat',
+          )
+        ))['product'];
+
+        // Creates the plan within the Vindi
+        $createPlan = $this->routes->createPlan(array(
+          'name' => PREFIX_PLAN . $data['name'],
+          'interval' => $product->get_meta('_subscription_period') . 's',
+          'interval_count' => intval($product->get_meta('_subscription_period_interval')),
+          'billing_trigger_type' => 'beginning_of_period',
+          'billing_trigger_day' => $product->get_meta('_subscription_trial_length'),
+          'billing_cycles' => ($product->get_meta('_subscription_length') == 0) ? null : $product->get_meta('_subscription_length'),
+          'code' => 'WC-' . $data['id'],
+          'description' => $data['description'],
+          'installments' => 1,
+          'status' => ($data['status'] == 'publish') ? 'active' : 'inactive',
+          'plan_items' => array(
+            array(
+              'cycles' => $product->get_meta('_subscription_length'),
+              'product_id' => $createProduct['id']
+            ),
+          ),
+        ))['plan'];
+
+        // Saving product id and plan in the WC goal
+        VindiHelpers::wc_post_meta($data['id'], array(
+          'vindi_product_id' => $createProduct['id'],
+          'vindi_plan_id' => $createPlan['id'],
+        ));
+
+        update_post_meta( $post_id, 'vindi_product_created', true );
+
+      }
+
+      die();
     }
 
     $data = $product->get_data();

--- a/src/includes/gateways/BankSlipPayment.php
+++ b/src/includes/gateways/BankSlipPayment.php
@@ -17,8 +17,8 @@ class VindiBankSlipGateway extends VindiPaymentGateway
   /**
    * @var VindiSettings
    */
-   private $vindi_settings;
- 
+  private $vindi_settings;
+
   /**
    * Constructor for the gateway.
    */

--- a/src/routes/RoutesApi.php
+++ b/src/routes/RoutesApi.php
@@ -22,6 +22,26 @@ class VindiRoutes
   }
 
   /**
+   * Enough if there is a product within Vindi
+   *
+   * @since 1.0.0
+   * @version 1.0.0
+   * @return array
+   */
+  public function findProductById($product_id)
+  {
+
+    $response = $this->api->request(sprintf(
+      'product/%s',
+      $product_id
+    ), 'GET');
+
+
+    return $response;
+  }
+
+
+  /**
    * Post method for creating plan in the Vindi
    *
    * @since 1.0.0

--- a/src/utils/Conversions.php
+++ b/src/utils/Conversions.php
@@ -1,0 +1,34 @@
+<?php
+
+
+class VindiConversions {
+
+/**
+ * Converts the months, weeks and years of a Trial period into days.
+ *
+ * Used to send days in parameter  to Vindi.
+ *
+ *
+ * @since 1.0.0
+ *
+ * @return number
+ */
+  public static function convertTriggerToDay($number, $type = 'month') {
+    $types = array(
+      "month" => 30,
+      "week" => 7,
+      "year" => 365,
+    );
+
+    $verifyType = $types[$type];
+
+    if(!$verifyType) {
+      return false;
+    }
+
+    return $number * $verifyType;
+
+  }
+}
+
+?>

--- a/src/utils/Conversions.php
+++ b/src/utils/Conversions.php
@@ -15,6 +15,7 @@ class VindiConversions {
  */
   public static function convertTriggerToDay($number, $type = 'month') {
     $types = array(
+      "day" => 1,
       "month" => 30,
       "week" => 7,
       "year" => 365,

--- a/src/utils/Conversions.php
+++ b/src/utils/Conversions.php
@@ -9,7 +9,7 @@ class VindiConversions {
  * Used to send days in parameter  to Vindi.
  *
  *
- * @since 1.0.0
+ * @since 1.0.1
  *
  * @return number
  */
@@ -27,7 +27,7 @@ class VindiConversions {
       return false;
     }
 
-    return $number * $verifyType;
+    return intval($number) * intval($verifyType);
 
   }
 }

--- a/src/utils/DefinitionVariables.php
+++ b/src/utils/DefinitionVariables.php
@@ -7,17 +7,17 @@ define('VINDI_MININUM_PHP_VERSION', '5.6');
 
 define('VINDI', 'vindi-woocommerce');
 
-define('VINDI__FILE__', dirname(dirname(__FILE__)));
-define('VINDI_PLUGIN_BASE', plugin_basename(VINDI__FILE__));
-define('VINDI_PATH', plugin_dir_path(VINDI__FILE__));
+define('VINDI_FILE', dirname(dirname(__FILE__)));
+define('VINDI_PLUGIN_BASE', plugin_basename(VINDI_FILE));
+define('VINDI_PATH', plugin_dir_path(VINDI_FILE));
 
-define('VINDI_SRC', plugin_dir_path(VINDI__FILE__) . '/src/');
+define('VINDI_SRC', plugin_dir_path(VINDI_FILE) . '/src/');
 
 
 if (defined('VINDI_TESTS') && VINDI_TESTS) {
   define('VINDI_URL', 'file://' . VINDI_PATH);
 } else {
-  define('VINDI_URL', plugins_url('/', VINDI__FILE__));
+  define('VINDI_URL', plugins_url('/', VINDI_FILE));
 }
 
 define('PREFIX_PRODUCT', '[WC] ');

--- a/src/validators/DependenciesNotices.php
+++ b/src/validators/DependenciesNotices.php
@@ -14,13 +14,13 @@ function dependencies_notices()
   if (!class_exists('WC_Payment_Gateway')) {
     include_once VINDI_SRC . 'views/woocommerce-missing.php';
 
-    deactivate_plugins(VINDI_PATH . '/' . PLUGIN_FILE, true);
+    deactivate_plugins(VINDI_PATH . '/' . VINDI_FILE, true);
   }
 
   if (!class_exists('Extra_Checkout_Fields_For_Brazil')) {
     include_once VINDI_SRC . 'views/ecfb-missing.php';
 
-    deactivate_plugins(VINDI_PATH . '/' . PLUGIN_FILE, true);
+    deactivate_plugins(VINDI_PATH . '/' . VINDI_FILE, true);
   }
 };
 

--- a/tests/phpunit/vindi/base/test-vindi.php
+++ b/tests/phpunit/vindi/base/test-vindi.php
@@ -11,7 +11,7 @@ class Vindi_Test extends Vindi_Test_Base
     $this->assertTrue(defined('VINDI'));
     $this->assertTrue(defined('VINDI_MININUM_WP_VERSION'));
     $this->assertTrue(defined('VINDI_MININUM_PHP_VERSION'));
-    $this->assertTrue(defined('VINDI__FILE__'));
+    $this->assertTrue(defined('VINDI_FILE'));
     $this->assertTrue(defined('VINDI_PLUGIN_BASE'));
     $this->assertTrue(defined('VINDI_PATH'));
   }


### PR DESCRIPTION
@thihxm , criei o Método que atualiza as informações de um Plano e um Produto dentro da Vindi;

Basicamente, caso o produto não esteja cadastrado dentro da Vindi, o Método Update retorna para o Create(), caso contrário a Informações são alteradas;


Também criei uma função pública e estática apenas para convertes os retornos Trial do WC para o reconhecimento da API da Vindi como mostrado abaixo: 

![image](https://user-images.githubusercontent.com/36010251/79767386-a5505c80-82ff-11ea-8eb3-dd2e9a0d42f3.png)


