### PR TITLE
webhook bill canceled

### DIFF
--- a/src/includes/SubscriptionStatusHandler.php
+++ b/src/includes/SubscriptionStatusHandler.php
@@ -21,7 +21,11 @@ class VindiSubscriptionStatusHandler
     ), 1, 3);
 
     add_action('woocommerce_order_fully_refunded', array(
-      &$this, 'refunded_status'
+      &$this, 'order_fully_refunded'
+    ));
+
+    add_action('woocommerce_order_status_cancelled', array(
+      &$this, 'order_canceled'
     ));
   }
 
@@ -98,9 +102,9 @@ class VindiSubscriptionStatusHandler
   }
 
   /**
-   * @param WC_Subscription $wc_subscription
+   * @param WC_Order $order
    */
-  public function refunded_status($order)
+  public function order_fully_refunded($order)
   {
     if (!is_object($order)) {
       $order = wc_get_order($order);
@@ -124,5 +128,33 @@ class VindiSubscriptionStatusHandler
         }
       }
     }
+  }
+
+  /**
+   * @param WC_Order $order
+   */
+  public function order_canceled($order)
+  {
+    if (!is_object($order)) {
+      $order = wc_get_order($order);
+    }
+
+    $vindi_order = get_post_meta($order->id, 'vindi_order', true);
+    if(!is_array($vindi_order)) {
+      return;
+    }
+    $single_payment_bill_id = 0;
+    foreach ($vindi_order as $key => $item) {
+      if($key == 'single_payment' && $vindi_order[$key]['bill']['status'] != 'canceled') {
+        $single_payment_bill_id = $vindi_order[$key]['bill']['id'];
+      }
+      $vindi_order[$key]['bill']['status'] = 'canceled';
+    }
+    update_post_meta($order->id, 'vindi_order', $vindi_order);
+    if($single_payment_bill_id) {
+      $this->routes->deleteBill($single_payment_bill_id);
+    }
+  
+    $this->vindi_settings->logger->log('Um pedido foi cancelado');
   }
 }

--- a/src/includes/SubscriptionStatusHandler.php
+++ b/src/includes/SubscriptionStatusHandler.php
@@ -154,7 +154,5 @@ class VindiSubscriptionStatusHandler
     if($single_payment_bill_id) {
       $this->routes->deleteBill($single_payment_bill_id);
     }
-  
-    $this->vindi_settings->logger->log('Um pedido foi cancelado');
   }
 }

--- a/src/templates/bankslip-download.html.php
+++ b/src/templates/bankslip-download.html.php
@@ -8,7 +8,7 @@
 		</span>
 		<br><br>
 		<?php foreach ($vindi_order as $item): ?>
-			<?php if ($item['bill']['status'] != 'paid'): ?>
+			<?php if (!in_array($item['bill']['status'], array('paid', 'canceled'))): ?>
 				<span>
 					<a class="button" href="<?php echo esc_url($item['bill']['bank_slip_url']); ?>" target="_blank">
 						<?php _e('Baixar boleto', VINDI ); ?>


### PR DESCRIPTION
Adicionado suporte ao Webhook bill_canceled. Caso uma fatura seja cancelada na vindi, o pedido é cancelado na vindi. E agor, se um pedido é cancelado no woocommerce, a fatura de pagamento único também é cancelada na vindi. Antes só eram canceladas as assinaturas.
