### PR TITLE
Ajusta validação de certificado SSL por tipo de ambiente

### DIFF
--- a/src/VindiWoocommerce.php
+++ b/src/VindiWoocommerce.php
@@ -11,11 +11,6 @@ class WC_Vindi_Payment extends AbstractInstance
   /**
    * @var string
    */
-  const MODE = 'development';
-
-  /**
-   * @var string
-   */
   const WC_API_CALLBACK = 'vindi_webhook';
 
   /**

--- a/src/includes/admin/Settings.php
+++ b/src/includes/admin/Settings.php
@@ -235,12 +235,12 @@ class VindiSettings extends WC_Settings_API
   }
 
   /**
-   * Check if SSL is enabled when merchant is not trial.
+   * Check if SSL is enabled when merchant is not in sandbox.
    * @return boolean
    */
-  public static function check_ssl()
+  public function check_ssl()
   {
-    if ($this->routes->isMerchantStatusTrialOrSandbox()) {
+    if ($this->get_is_active_sandbox()) {
       return true;
     } else {
       return is_ssl();

--- a/src/includes/admin/Settings.php
+++ b/src/includes/admin/Settings.php
@@ -240,8 +240,8 @@ class VindiSettings extends WC_Settings_API
    */
   public static function check_ssl()
   {
-    if (WC_Vindi_Payment::MODE != 'development') {
-      return false;
+    if ($this->routes->isMerchantStatusTrialOrSandbox()) {
+      return true;
     } else {
       return is_ssl();
     }


### PR DESCRIPTION
### Motivação
A mensagem de necessidade do certificado de segurança SSL só deve ser exibida caso o cliente esteja usando o ambiente de produção e está sendo exibida em todo o momento.

### Solução proposta
Ajustar a verificação para quando um cliente estiver utilizando _sandbox_ o aviso seja removido.