### PR TITLE
 Ajusta URL de retorno para webhooks Vindi

### DIFF
--- a/src/VindiWoocommerce.php
+++ b/src/VindiWoocommerce.php
@@ -11,11 +11,6 @@ class WC_Vindi_Payment extends AbstractInstance
   /**
    * @var string
    */
-  const MODE = 'development';
-
-  /**
-   * @var string
-   */
   const WC_API_CALLBACK = 'vindi_webhook';
 
   /**

--- a/src/includes/admin/Settings.php
+++ b/src/includes/admin/Settings.php
@@ -302,7 +302,7 @@ class VindiSettings extends WC_Settings_API
   }
 
 	public function get_webhooks_url() {
-		return sprintf('%s/wc-api/%s?token=%s',
+		return sprintf('%s/index.php/wc-api/%s?token=%s',
       get_site_url(),
       WC_Vindi_Payment::WC_API_CALLBACK,
       $this->get_token()

--- a/src/includes/admin/Settings.php
+++ b/src/includes/admin/Settings.php
@@ -240,8 +240,8 @@ class VindiSettings extends WC_Settings_API
    */
   public static function check_ssl()
   {
-    if (WC_Vindi_Payment::MODE != 'development') {
-      return false;
+    if ($this->routes->isMerchantStatusTrialOrSandbox()) {
+      return true;
     } else {
       return is_ssl();
     }


### PR DESCRIPTION
Dependente do Pull Request #60 

### Motivação
A url de webhooks atual não suporta algumas configurações do `.htaccess` retornando o status HTTP 404 em alguns casos. 

### Solução proposta
Ajustar a url inserindo o _index_ do Wordpress para que o fluxo funcione corretamente :wrench: 